### PR TITLE
Changes google-auth-redirect from path-only to full url

### DIFF
--- a/lib/sinatra/google-auth.rb
+++ b/lib/sinatra/google-auth.rb
@@ -24,7 +24,7 @@ module Sinatra
     module Helpers
       def authenticate
         unless session["user"]
-          session['google-auth-redirect'] = request.path
+          session['google-auth-redirect'] = request.url
           if settings.absolute_redirect?
             redirect "/auth/google_apps"
           else


### PR DESCRIPTION
This makes sure all parameters sent in the first request are included
when app redirects to google-auth-redirect session variable
